### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Lists

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -2,7 +2,7 @@
   <div id="testelement" class="hidden" style="background-color: white"></div>
   <header>
     <p>Configure your list (large thumbnails)</p>
-    <a id="help_tip" href="#">Need help?</a>
+    <a href="https://help.fliplet.com/article/165-list-components">Need help?</a>
   </header>
 
   <ul class="nav nav-tabs" role="tablist">

--- a/js/interface.js
+++ b/js/interface.js
@@ -80,10 +80,6 @@ setTimeout(function() {
   });
 }, 1000);
 
-$('#help_tip').on('click', function() {
-  alert("During beta, please use live chat and let us know what you need help with.");
-});
-
 // EVENTS
 $(".tab-content")
   .on('click', '.icon-delete', function() {
@@ -449,7 +445,7 @@ function save(notifyComplete, dragStop) {
   linkPromises.forEach(function(promise) {
     promise.forwardSaveRequest();
   });
-  
+
   if (!dragStop) {
     Fliplet.Widget.all(linkPromises).then(function() {
       // when all providers have finished


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button. Removed not needed function.

Backward compatibility
This change is fully backward compatible.