### PR TITLE
changed version of widget (list large thumbnail) 4281

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "List (large thumbnails)",
   "package": "com.fliplet.list-large-thumbs",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "icon": "img/icon.png",
   "tags": ["type:component", "category:list"],
   "provider_only": false,


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4281
## Description
changed version of widget (list large thumbnail) for 1.0.0.
## Backward compatibility
This change is fully backward compatible.