### PR TITLE
Allow user to save widget after dismissing file picker

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -355,10 +355,13 @@ function initImageProvider(item) {
     if (event.data === 'cancel-button-pressed') {
       Fliplet.Widget.toggleCancelButton(true);
       imageProvider.close();
+      
       if (_.isEmpty(item.imageConf)) {
         $('[data-id="' + item.id + '"] .add-image-holder').find('.add-image').text('Add image');
         $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
       }
+
+      imageProvider = null;
     }
   });
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -360,7 +360,7 @@ function initImageProvider(item) {
         $('[data-id="' + item.id + '"] .add-image-holder').find('.add-image').text('Add image');
         $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
       }
-
+      Fliplet.Widget.resetSaveButtonLabel();
       imageProvider = null;
     }
   });

--- a/js/interface.js
+++ b/js/interface.js
@@ -360,6 +360,7 @@ function initImageProvider(item) {
         $('[data-id="' + item.id + '"] .add-image-holder').find('.add-image').text('Add image');
         $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
       }
+
       Fliplet.Widget.resetSaveButtonLabel();
       imageProvider = null;
     }


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5215

## Description
Allow user to save widget after dismissing file picker

## Screenshots/screencasts
![issue5015](https://user-images.githubusercontent.com/53430352/68658360-f765a880-053d-11ea-9549-32372ee60b71.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
This PR for the production version. [Origin](https://github.com/Fliplet/fliplet-widget-list-large-thumbs/pull/26).