### PR TITLE
Title list is centered vertically

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -42,11 +42,13 @@
 }
 
 .list.list-thumb-l ul > li {
-	list-style: none;
+	align-items: center;
 	border-bottom: 1px solid rgba(51,51,51,0.2);
+	display: flex;
+	list-style: none;
+	min-height: 71px;
 	padding: 10px 10px 10px 86px;
 	position: relative;
-	min-height: 71px;
 }
 
 .list.list-thumb-l ul > li .list-swipe-wrapper {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#5367

## Description
Centered vertically with flex.

## Screenshots/screencasts
![large-thumbs](https://user-images.githubusercontent.com/52824207/71986035-686ec700-3234-11ea-9047-ac3c8dff27c5.PNG)

## Backward compatibility
This change is fully backward compatible.