### PR TITLE
Allow user to save widget after dismissing icon picker

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -300,18 +300,20 @@ function initIconProvider(item) {
     }
   });
 
+  Fliplet.Widget.toggleCancelButton(false);
+
   window.addEventListener('message', function(event) {
     if (event.data === 'cancel-button-pressed') {
       iconProvider.close();
       iconProvider = null;
+
       if (!item.icon.length) {
         $('[data-id="' + item.id + '"] .add-icon-holder').find('.add-icon').text('Select an icon');
         $('[data-id="' + item.id + '"] .add-icon-holder').find('.icon-holder').addClass('hidden');
       }
 
-      Fliplet.Studio.emit('widget-save-label-update', {
-        text: 'Save'
-      });
+      Fliplet.Widget.resetSaveButtonLabel();
+      imageProvider = null;
     }
   });
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5650

## Description
Allow user to save widget after dismissing icon picker

## Screenshots/screencasts
https://share.getcloudapp.com/6quBwlK9

## Backward compatibility

This change is fully backward compatible.