### PR TITLE
When a user closes the interface there will be no console error

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -286,10 +286,16 @@ function initLinkProvider(item) {
 
 function initListener(provider, item) { 
   window.addEventListener('message', function onMessage(event) {
+    // Removes listener and enables the cancel button when the provider is saved and closed
+    if (event.data === 'save-widget') {
+      window.removeEventListener('message', onMessage);
+      Fliplet.Widget.toggleCancelButton(true);
+    }
+
     if (event.data === 'cancel-button-pressed') {
       switch (provider) {
         case 'icon':
-          onIconClose(item);         
+          onIconClose(item);
           break;
         case 'image':
           onImageClose(item);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5650#issuecomment-608500527

## Description
When a user closes the interface there will be no console error

## Screenshots/screencasts
https://share.getcloudapp.com/rRu9vgkN

## Backward compatibility

This change is fully backward compatible.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 