### PR TITLE
[Fix] Not allow users click save button when no icon is selected

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -308,6 +308,7 @@ function initListener(provider, item) {
 
       window.removeEventListener('message', onMessage);
       Fliplet.Widget.toggleCancelButton(true);
+      Fliplet.Widget.toggleSaveButton(true);
       Fliplet.Widget.resetSaveButtonLabel();
     }
   });
@@ -345,8 +346,15 @@ function initIconProvider(item) {
     data: item,
     // Events fired from the provider
     onEvent: function(event, data) {
-      if (event === 'interface-validate') {
-        Fliplet.Widget.toggleSaveButton(data.isValid === true);
+      switch (event) {
+        case 'interface-validate':
+          Fliplet.Widget.toggleSaveButton(!!data.isValid);
+          break;
+        case 'icon-clicked':
+          Fliplet.Widget.toggleSaveButton(data.isSelected);
+          break;
+        default:
+          break;
       }
     }
   });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5651

## Description
Not allow users to click save button when no icon is selected

## Screenshots/screencasts
https://share.getcloudapp.com/6qu5gwJL

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko