### PR TITLE
[Fix] Do not show errors when users click close image or icon providers. For production version.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -84,7 +84,7 @@ setTimeout(function() {
       dragging = false;
       save(false, true);
     },
-    sort: function(event, ui) {
+    sort: function() {
       $('.panel-group').sortable('refresh');
       $('.tab-content').trigger('scroll');
     }
@@ -113,12 +113,15 @@ $(".tab-content")
     checkPanelLength();
   })
   .on('click', '.add-image', function() {
+    if (imageProvider) {
+      return;
+    }
 
-    var $item = $(this).closest("[data-id], .panel"),
-      id = $item.data('id'),
-      item = _.find(data.items, {
-        id: id
-      });
+    var $item = $(this).closest('[data-id], .panel');
+    var id = $item.data('id');
+    var item = _.find(data.items, {
+      id: id
+    });
 
     initImageProvider(item);
 
@@ -141,11 +144,15 @@ $(".tab-content")
     save();
   })
   .on('click', '.add-icon', function() {
-    var $item = $(this).closest("[data-id], .panel"),
-      id = $item.data('id'),
-      item = _.find(data.items, {
-        id: id
-      });
+    if (iconProvider) {
+      return;
+    }
+
+    var $item = $(this).closest('[data-id], .panel');
+    var id = $item.data('id');
+    var item = _.find(data.items, {
+      id: id
+    });
 
     initIconProvider(item);
 
@@ -234,7 +241,7 @@ $(".tab-content")
 var contentHeight = $('body > .form-horizontal').outerHeight();
 var tabPaneTopPadding = 78;
 
-$('body > .form-horizontal').scroll(function(event) {
+$('body > .form-horizontal').scroll(function() {
   var tabContentScrollPos = Math.abs($('.tab-pane-content').position().top - tabPaneTopPadding);
   var tabPaneHeight = tabPaneTopPadding + $('.tab-pane-content').height();
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -287,6 +287,53 @@ function initLinkProvider(item) {
   linkPromises.push(linkActionProvider);
 }
 
+function initListener(provider, item) { 
+  window.addEventListener('message', function onMessage(event) {
+    // Removes listener and enables the cancel button when the provider is saved and closed
+    if (event.data === 'save-widget') {
+      window.removeEventListener('message', onMessage);
+      Fliplet.Widget.toggleCancelButton(true);
+    }
+
+    if (event.data === 'cancel-button-pressed') {
+      switch (provider) {
+        case 'icon':
+          onIconClose(item);
+          break;
+        case 'image':
+          onImageClose(item);
+          break;
+      }
+
+      window.removeEventListener('message', onMessage);
+      Fliplet.Widget.toggleCancelButton(true);
+      Fliplet.Widget.resetSaveButtonLabel();
+    }
+  });
+}
+
+function onIconClose(item) {
+    iconProvider.close();
+
+    if (!item.icon.length) {
+      $('[data-id="' + item.id + '"] .add-icon-holder').find('.add-icon').text('Select an icon');
+      $('[data-id="' + item.id + '"] .add-icon-holder').find('.icon-holder').addClass('hidden');
+    }
+
+    iconProvider = null;
+}
+
+function onImageClose(item) {
+    imageProvider.close();
+
+    if (_.isEmpty(item.imageConf)) {
+      $('[data-id="' + item.id + '"] .add-image-holder').find('.add-image').text('Add image');
+      $('[data-id="' + item.id + '"] .add-image-holder').find('.thumb-holder').addClass('hidden');
+    }
+
+    imageProvider = null;
+}
+
 var iconProvider;
 function initIconProvider(item) {
   item.icon = item.icon || '';


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5650

## Description
Do not allow multiple providers.

## Screenshots/screencasts
https://share.getcloudapp.com/d5uvQzog

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko