### PR TITLE
OD-296 [Fix] Show only saved items after 'swipe to save'

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -19,14 +19,6 @@
 	cursor: pointer;
 }
 
-.list.list-thumb-l ul.list-holder > li.saved {
-	display: flex;
-}
-
-.list.list-thumb-l.saved-list ul.list-holder > li:not(.saved) {
-	display: none;
-}
-
 .list.list-thumb-l ul > li .list-title {
 	font-size: 1em;
 	font-weight: 600;
@@ -52,7 +44,6 @@
 .list.list-thumb-l ul > li {
 	align-items: center;
 	border-bottom: 1px solid rgba(51,51,51,0.2);
-	display: flex;
 	list-style: none;
 	min-height: 71px;
 	padding: 10px 10px 10px 86px;

--- a/css/build.css
+++ b/css/build.css
@@ -19,6 +19,14 @@
 	cursor: pointer;
 }
 
+.list.list-thumb-l ul.list-holder > li.saved {
+	display: flex;
+}
+
+.list.list-thumb-l.saved-list ul.list-holder > li:not(.saved) {
+	display: none;
+}
+
 .list.list-thumb-l ul > li .list-title {
 	font-size: 1em;
 	font-weight: 600;

--- a/js/build.js
+++ b/js/build.js
@@ -33,7 +33,7 @@ Fliplet.Widget.instance('list-thumb-l', function(data) {
   $container.on('click', '.filter-' + data.id, function(event) {
     var dataset = event.target.dataset;
 
-    $container.toggleClass('saved-list', dataset.filter && dataset.filter === '.saved');
+    $container.toggleClass('saved-list', dataset.filter === '.saved');
   });
 
   if (data.swipeToSave) {

--- a/js/build.js
+++ b/js/build.js
@@ -30,12 +30,6 @@ Fliplet.Widget.instance('list-thumb-l', function(data) {
     }
   });
 
-  $container.on('click', '.filter-' + data.id, function(event) {
-    var dataset = event.target.dataset;
-
-    $container.toggleClass('saved-list', dataset.filter === '.saved');
-  });
-
   if (data.swipeToSave) {
     ui['swipeSavedList' + $container.attr('data-list-thumb-l-uuid')] = new SwipeSaveList(this, {
       savedListLabel: data.swipeToSaveLabel || 'My list'

--- a/js/build.js
+++ b/js/build.js
@@ -30,6 +30,12 @@ Fliplet.Widget.instance('list-thumb-l', function(data) {
     }
   });
 
+  $container.on('click', '.filter-' + data.id, function(event) {
+    var dataset = event.target.dataset;
+
+    $container.toggleClass('saved-list', dataset.filter && dataset.filter === '.saved');
+  });
+
   if (data.swipeToSave) {
     ui['swipeSavedList' + $container.attr('data-list-thumb-l-uuid')] = new SwipeSaveList(this, {
       savedListLabel: data.swipeToSaveLabel || 'My list'


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-296 https://weboo.atlassian.net/browse/OD-296
## Description
After saving items using 'Swipe to save' feature show only saved items in user's list.
## Screenshots/screencasts
https://screencast-o-matic.com/watch/crVh6rPlOG
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz
## Notes
Should be cherry-picked in version 1.0.0 after merge.