### PR TITLE
XOR-317 [Fix] Ensure hide saved list name until Swipe to Save feature is enabled

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -54,7 +54,7 @@ body {
   color: #c9302c;
 }
 
-.radio.radio-icon+.radio.radio-icon {
+.radio.radio-icon + .radio.radio-icon {
   margin-top: 0;
 }
 
@@ -120,7 +120,7 @@ body {
   top: 0;
   right: 0;
   opacity: 0;
-  color: #E60000;
+  color: #e60000;
   width: 38px;
   height: 38px;
   line-height: 38px;
@@ -287,4 +287,8 @@ textarea.form-control {
 
 .thumb-holder .image-remove {
   margin-left: 10px;
+}
+
+#saved-list-field {
+  display: none;
 }


### PR DESCRIPTION
**Product areas affected**
List(Large Thumbnails) -> Swipe to Save -> Enable Swipe to Save

**What does this PR do?**
Implemented fix so on toggling Swipe to Save from List Large Thumbnails saved list name hiding. 

**JIRA ticket**
[JIRA](https://weboo.atlassian.net/browse/XOR-317)

**Result**

https://user-images.githubusercontent.com/108272606/181553633-21ae4f17-9c2a-4779-8a10-6f03c6ccb838.mp4

**Checklist**
none

**Testing instructions**
none

**Deployment instructions**
none

**Author concerns**
none
